### PR TITLE
Fix inttypes inclusion

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 
 #include "psa/crypto.h"
 #include <string.h>


### PR DESCRIPTION
__STDC_FORMAT_MACROS needs to be added for format specifiers like PRId32
IAR/ARMCC do not define it