### PR TITLE
Add github issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,44 @@
+<!--
+
+   ************************************** WARNING **************************************
+
+   The ciarcom bot parses this header automatically. Any deviation from the 
+   template may cause the bot to automatically correct this header or may result in a 
+   warning message, requesting updates.
+
+   Please ensure that nothing follows the Issue request type section, all 
+   issue details are within the Description section and no changes are made to the 
+   template format (as detailed below).
+
+   *************************************************************************************
+
+-->
+
+### Description
+
+<!--
+    Required
+    Add detailed description of what you are reporting.
+    Good example: https://os.mbed.com/docs/latest/reference/workflow.html
+    Things to consider sharing:
+    - What target does this relate to?
+    - What toolchain (name + version) are you using?
+    - What tools (name + version - is it mbed-cli, online compiler or IDE) are you using?
+    - What is the SHA of Mbed OS (git log -n1 --oneline)?
+    - Steps to reproduce. (Did you publish code or a test case that exhibits the problem?)
+-->
+
+
+### Issue request type
+
+<!--
+    Required
+    Please add only one X to one of the following types. Do not fill multiple types (split the issue otherwise.)
+    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
+    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
+    description heading and to add a 'x' to the correct box.
+-->
+    [ ] Question
+    [ ] Enhancement
+    [ ] Bug
+


### PR DESCRIPTION
Github issue template required for internal issue tracking in Jira.