### PR TITLE
Update example to use Mbed OS 5.11.2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c966348d3f9ca80843be7cdc9b748f06ea73ced0
+https://github.com/ARMmbed/mbed-os/#a8f0c33eaa2c52babff9655417c36f4b5edd54d7

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,8 @@
     "target_overrides": {
         "*": {
              "platform.stdio-convert-newlines": true,
-             "target.extra_labels_add": ["PSA"]
+             "target.extra_labels_add": ["PSA"],
+             "target.components_remove": ["SD"]
         }
     },
     "macros": [


### PR DESCRIPTION
After updating to Mbed OS 5.11.2, Mbed OS prefers to use SD for storage over FLASHIAP if both are present. As the example should work on a K64F even without an SD, the SD component is removed to force Mbed OS to use FLASHIAP.