### PR TITLE
Support non-PSA targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ cipher encrypt/decrypt AES CTR multipart:
         success!
 ```
 
-Any subsequent run where entropy is already present, or if entropy injection is
-not enabled, will result in the following acceptable output:
+Any subsequent run where entropy is already present will result in the
+following acceptable output:
 ```
 warning (-133) - this attempt at entropy injection failed
 cipher encrypt/decrypt AES CBC no padding:

--- a/main.cpp
+++ b/main.cpp
@@ -340,6 +340,7 @@ static void cipher_examples(void)
     }
 }
 
+#if defined(MBEDTLS_PSA_INJECT_ENTROPY)
 static void fake_set_initial_nvseed(void)
 {
     /* This function, fake_set_initial_nvseed(), is useless on platforms that
@@ -367,10 +368,13 @@ static void fake_set_initial_nvseed(void)
                        " failed\n", status);
     }
 }
+#endif
 
 int main(void)
 {
+#if defined(MBEDTLS_PSA_INJECT_ENTROPY)
     fake_set_initial_nvseed();
+#endif
 
     ASSERT_STATUS(psa_crypto_init(), PSA_SUCCESS);
     cipher_examples();

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,6 @@
     "target_overrides": {
         "*": {
              "platform.stdio-convert-newlines": true,
-             "target.extra_labels_add": ["PSA"],
              "target.components_remove": ["SD"]
         }
     },

--- a/mbedtls_user_config.h
+++ b/mbedtls_user_config.h
@@ -23,11 +23,13 @@
 #endif
 
 /* Enable the default implementation of the PSA entropy injection API if we are
- * building for an SPE. */
+ * building for an SPE and PSA storage is available. */
 #if defined(COMPONENT_PSA_SRV_IMPL) || defined(COMPONENT_PSA_SRV_EMUL)
-#   define MBEDTLS_ENTROPY_NV_SEED
-#   define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
-#   define MBEDTLS_PSA_INJECT_ENTROPY
-#   define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbed_default_seed_read
-#   define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbed_default_seed_write
+#   if defined(TARGET_PSA)
+#       define MBEDTLS_PSA_CRYPTO_STORAGE_C
+#       define MBEDTLS_ENTROPY_NV_SEED
+#       define MBEDTLS_PSA_INJECT_ENTROPY
+#       define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbed_default_seed_read
+#       define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbed_default_seed_write
+#   endif
 #endif


### PR DESCRIPTION
Enable use of this example on non-PSA targets, those where PSA storage
is not available, by optionally enabling the PSA entropy injection API
based on the availability of PSA storage.

The this example can now run without PSA entropy injection, also update
README to reflect when the entropy injection warning may occur.