### PR TITLE
Work around ARM and IAR optimization issue

### DIFF
--- a/getting-started/mbed_profile.json
+++ b/getting-started/mbed_profile.json
@@ -1,0 +1,15 @@
+{
+    "GCC_ARM": {},
+    "ARMC6": {
+        "common": ["-O1"]
+    },
+    "ARM": {
+        "common": ["-O1"]
+    },
+    "uARM": {
+        "common": ["-O1"]
+    },
+    "IAR": {
+        "common": ["-Ol"]
+    }
+}


### PR DESCRIPTION
Add a custom profile to work around an issue with the ARM and IAR
compilers, where the example appears to hang without any error. Building
the example with `-O1`, rather than the default of `-Os`, works as a
workaround.

To use the custom profile with mbed-cli, use the --profile option.

    mbed compile -m CY8CKIT_062_WIFI_BT -t ARMC6 --profile mbed_profile.json

Arm internal reference: SDCTRESPONSE-3550