### PR TITLE
Include "mbed.h" to enable GCC_ARM build with "-flto" 

### DIFF
--- a/getting-started/main.cpp
+++ b/getting-started/main.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "mbed.h"
 #include "psa/crypto.h"
 #include "mbedtls/version.h"
 #include <string.h>


### PR DESCRIPTION
Add the "mbed.h" header to use the MBED_USED attribute with main().

Since the "used" attribute and the definition of main() have to be in
the same translation unit, I placed a declaration of main() in
"platform/mbed_toolchain.h" which "mbed.h" includes.

Without the attribute, the main() symbol is not emitted with the GCC
toolchain using "-Wl,--wrap,main" and "-flto" flags.

This patch is required by https://github.com/ARMmbed/mbed-os/pull/11856.