### PR TITLE
Enable experimental api for getting started example

### DIFF
--- a/getting-started/mbed_app.json
+++ b/getting-started/mbed_app.json
@@ -2,6 +2,7 @@
     "target_overrides": {
         "*": {
              "platform.stdio-convert-newlines": true,
+             "target.features_add" : ["EXPERIMENTAL_API"],
              "target.components_remove": ["SD"]
         }
     },


### PR DESCRIPTION
PSA Crypto is being marked as experimental. As this example depends on PSA Crypto, we need to enable the EXPERIMENTAL_API feature in order to use it.