### PR TITLE
Update for mbed-os-6.1.0

### DIFF
--- a/getting-started/mbed-os.lib
+++ b/getting-started/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#165be79392ae7b1bee4388d2bc8ed8281978f07c
+https://github.com/ARMmbed/mbed-os/#a6207cadad0acd1876f436dc6baeddf46c42af06


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.1.0 release of mbed-os. 