### PR TITLE
Update for mbed-os-6.2.1

### DIFF
--- a/getting-started/mbed-os.lib
+++ b/getting-started/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.2.1 release of mbed-os. 