### PR TITLE
CMake: Add required Mbed OS component

### DIFF
--- a/getting-started/CMakeLists.txt
+++ b/getting-started/CMakeLists.txt
@@ -29,7 +29,10 @@ target_sources(${APP_TARGET}
         main.cpp
 )
 
-target_link_libraries(${APP_TARGET} mbed-os)
+target_link_libraries(${APP_TARGET}
+    mbed-os
+    mbed-os-psa
+)
 
 mbed_generate_bin_hex(${APP_TARGET})
 


### PR DESCRIPTION
Mbed OS has multiple targets that can be linked to as required.

Reviewers: @0xc0170 @rajkan01 