### PR TITLE
Update for mbed-os-6.4.0

### DIFF
--- a/getting-started/mbed-os.lib
+++ b/getting-started/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0db72d0cf26539016efbe38f80d6f2cb7a3d4414
+https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.4.0 release of mbed-os. 