### PR TITLE
Remove deprecated function from CMakeLists.txt

### DIFF
--- a/getting-started/CMakeLists.txt
+++ b/getting-started/CMakeLists.txt
@@ -15,8 +15,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 # Provide Mbed OS with the header file it needs to configure Mbed TLS


### PR DESCRIPTION
`mbed_set_mbed_target_linker_script` was removed from mbed-os.

This PR depends on ARMmbed/mbed-os#14199