### PR TITLE
Update location of Mbed OS cmake config file

### DIFF
--- a/getting-started/CMakeLists.txt
+++ b/getting-started/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET getting-started)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)


### PR DESCRIPTION
Mbed OS tools now generates Mbed OS cmake config file in build folder instead of root folder (https://github.com/ARMmbed/mbed-tools/pull/189). Update `CMakeLists.txt` to use build folder to locate Mbed OS cmake
config file.