### PR TITLE
Update for mbed-os-6.9.0

### DIFF
--- a/getting-started/mbed-os.lib
+++ b/getting-started/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#26606218ad9d1ee1c8781aa73774fd7ea3a7658e
+https://github.com/ARMmbed/mbed-os/#c73413893fb98aaaeda74513c981ac68adc8645d


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.9.0 release of mbed-os. 