### PR TITLE
Support PSA Crypto from TF-M

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,3 +84,15 @@ matrix:
     - <<: *cmake-build-test
       name: "CMake PSA Crypto example - debug (K64F)"
       env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake PSA Crypto example - develop (ARM_MUSCA_S1)"
+      env: NAME=cmake_test TARGET_NAME=ARM_MUSCA_S1 PROFILE=develop CACHE_NAME=develop-ARM_MUSCA_S1
+
+    - <<: *cmake-build-test
+      name: "CMake PSA Crypto example - release (ARM_MUSCA_S1)"
+      env: NAME=cmake_test TARGET_NAME=ARM_MUSCA_S1 PROFILE=release CACHE_NAME=release-ARM_MUSCA_S1
+
+    - <<: *cmake-build-test
+      name: "CMake PSA Crypto example - debug (ARM_MUSCA_S1)"
+      env: NAME=cmake_test TARGET_NAME=ARM_MUSCA_S1 PROFILE=debug CACHE_NAME=debug-ARM_MUSCA_S1

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
     - &cmake-build-test
       stage: "CMake"
-      name: "CMake Mbed Crypto example - develop (K64F)"
+      name: "CMake PSA Crypto example - develop (K64F)"
       env: NAME=cmake_test TARGET_NAME=K64F PROFILE=develop  CACHE_NAME=develop-K64F
       language: python
       python: 3.8
@@ -87,9 +87,9 @@ matrix:
         - cd ..
 
     - <<: *cmake-build-test
-      name: "CMake Mbed Crypto example - release (K64F)"
+      name: "CMake PSA Crypto example - release (K64F)"
       env: NAME=cmake_test TARGET_NAME=K64F PROFILE=release CACHE_NAME=release-K64F
 
     - <<: *cmake-build-test
-      name: "CMake Mbed Crypto example - debug (K64F)"
+      name: "CMake PSA Crypto example - debug (K64F)"
       env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@
 
 language: sh
 os: linux
-dist: xenial
-
-env:
-  global:
-    - PROFILE=develop
+dist: focal
 
 cache:
   pip: true
@@ -33,9 +29,8 @@ cache:
 addons:
   apt:
     sources:
-      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ focal main'
         key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
-      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
     packages:
       - cmake
       - ninja-build
@@ -74,17 +69,13 @@ matrix:
         # version, we must instead delete the Travis copy of CMake.
         - sudo rm -rf /usr/local/cmake*
         - pip install --upgrade mbed-tools
-        - pip install prettytable==0.7.2
-        - pip install future==0.16.0
-        - pip install "Jinja2>=2.10.1,<2.11"
-        - pip install "intelhex>=1.3,<=2.2.1"
-      script:
         - cd getting-started
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - pip install -r mbed-os/requirements.txt
+      script:
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
-        - cd ..
 
     - <<: *cmake-build-test
       name: "CMake PSA Crypto example - release (K64F)"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![](./resources/official_armmbed_example_badge.png)
-# Running Mbed Crypto examples on Mbed OS
+# Running PSA Crypto examples on Mbed OS
 This repository contains an example demonstrating the compilation and use of PSA Crypto on Mbed OS.
 
 ## Prerequisites
@@ -42,7 +42,7 @@ Your PC may take a few minutes to compile your code.
 
 ## Expected output
 ```
--- Begin Mbed Crypto Getting Started --
+-- Begin PSA Crypto Getting Started --
 
 Import an AES key...    Imported a key
 Sign a message...       Signed a message
@@ -56,7 +56,7 @@ Authenticate encrypt... Authenticated and encrypted
 Authenticate decrypt... Authenticated and decrypted
 Generate a key pair...  Exported a public key
 
--- End Mbed Crypto Getting Started --
+-- End PSA Crypto Getting Started --
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,34 +1,46 @@
 ![](./resources/official_armmbed_example_badge.png)
 # Running Mbed Crypto examples on Mbed OS
-This repository contains a set of examples demonstrating the compilation and use of Mbed Crypto on Mbed OS.
-
-List of examples contained within this repository:
-* Example code snippets for using the library, with [documentation](https://github.com/ARMmbed/mbed-crypto/blob/development/docs/getting_started.md).
+This repository contains an example demonstrating the compilation and use of PSA Crypto on Mbed OS.
 
 ## Prerequisites
-* Install <a href='https://github.com/ARMmbed/mbed-cli#installing-mbed-cli'>Mbed CLI</a>
+This example requires the PSA Crypto API:
+* On TF-M targets, this API is provided by TF-M and always enabled.
+* On other targets, Mbed OS PSA can be enabled by adding `target.extra_labels_add": ["MBED_PSA_SRV"]`
+to `target_overrides` in [`getting-started/mbed_app.json`](./getting-started/mbed_app.json). Note that
+this cannot coexist with TF-M.
 
-## Import
-The following are the steps required to install the application:
-1. Clone the repository: `git clone https://github.com/ARMmbed/mbed-os-example-mbed-crypto.git`
-1. Navigate to the "getting-started" example: `cd mbed-os-example-mbed-crypto/getting-started`
-1. Deploy the Mbed OS project: `mbed deploy`
+## Mbed OS build tools
 
-## Compile
-To compile the example program use `mbed compile` while specifying the target platform and the compiler.
-For example, in order to compile using the ARM GCC compiler and a K64F target platform use: `mbed compile -m K64F -t GCC_ARM`.
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-mbed-crypto`
 
-Once the compilation is completed successfully a binary file will be created: `./BUILD/K64F/GCC_ARM/getting-started.bin`
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-example-mbed-crypto`
 
-## Program your board
-1. Connect your Mbed device to the computer over USB.
-1. Copy the binary file (`getting-started.bin`) to the Mbed device.
+## Building and running
 
-## Run
-1. Connect to the Mbed Device using a serial client application of your choice.
-1. Press the reset button on the Mbed device to run the program.
+1. Change the current directory to `mbed-os-example-mbed-crypto/getting-started`.
+1. Connect a USB cable between the USB port on the board and the host computer.
+1. Run the following command to build the example project, program the microcontroller flash memory and open a serial monitor:
 
-The expected output from the first successful execution of the example program should be as follows:
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
+    ```
+
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
+    ```
+
+Your PC may take a few minutes to compile your code.
+
+## Expected output
 ```
 -- Begin Mbed Crypto Getting Started --
 

--- a/getting-started/main.cpp
+++ b/getting-started/main.cpp
@@ -139,7 +139,7 @@ static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
 {
     psa_status_t status;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    uint8_t hash[] = "INPUT_FOR_SIGN";
+    static const uint8_t hash[] = "INPUT_FOR_SIGN";
     uint8_t signature[PSA_ASYMMETRIC_SIGNATURE_MAX_SIZE] = {0};
     size_t signature_length;
     psa_key_handle_t handle;
@@ -187,7 +187,7 @@ static void encrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
     psa_status_t status;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg = PSA_ALG_CBC_NO_PADDING;
-    uint8_t plaintext[block_size] = SOME_PLAINTEXT;
+    static const uint8_t plaintext[block_size] = SOME_PLAINTEXT;
     uint8_t iv[block_size];
     size_t iv_len;
     uint8_t output[block_size];
@@ -251,7 +251,7 @@ static void decrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg = PSA_ALG_CBC_NO_PADDING;
     psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
-    uint8_t ciphertext[block_size] = SOME_CIPHERTEXT;
+    static const uint8_t ciphertext[block_size] = SOME_CIPHERTEXT;
     uint8_t iv[block_size] = ENCRYPTED_WITH_IV;
     uint8_t output[block_size];
     size_t output_len;
@@ -309,7 +309,7 @@ static void hash_a_message(void)
     psa_status_t status;
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
-    unsigned char input[] = { 'a', 'b', 'c' };
+    static const unsigned char input[] = { 'a', 'b', 'c' };
     unsigned char actual_hash[PSA_HASH_MAX_SIZE];
     size_t actual_hash_len;
 
@@ -345,8 +345,8 @@ static void verify_a_hash(void)
     psa_status_t status;
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
-    unsigned char input[] = { 'a', 'b', 'c' };
-    unsigned char expected_hash[] = {
+    static const unsigned char input[] = { 'a', 'b', 'c' };
+    static const unsigned char expected_hash[] = {
         0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde,
         0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
         0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad

--- a/getting-started/main.cpp
+++ b/getting-started/main.cpp
@@ -114,13 +114,6 @@ static void import_a_key(const uint8_t *key, size_t key_len)
     printf("Import an AES key...\t");
     fflush(stdout);
 
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
-
     /* Set key attributes */
     psa_set_key_usage_flags(&attributes, 0);
     psa_set_key_algorithm(&attributes, 0);
@@ -140,8 +133,6 @@ static void import_a_key(const uint8_t *key, size_t key_len)
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
@@ -155,13 +146,6 @@ static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
 
     printf("Sign a message...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Set key attributes */
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN);
@@ -193,8 +177,6 @@ static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void encrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
@@ -215,14 +197,6 @@ static void encrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
 
     printf("Encrypt with cipher...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS)
-    {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Import a key */
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_ENCRYPT);
@@ -266,8 +240,6 @@ static void encrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void decrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
@@ -287,14 +259,6 @@ static void decrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
 
     printf("Decrypt with cipher...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS)
-    {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Import a key */
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DECRYPT);
@@ -338,8 +302,6 @@ static void decrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void hash_a_message(void)
@@ -353,13 +315,6 @@ static void hash_a_message(void)
 
     printf("Hash a message...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Compute hash of message  */
     status = psa_hash_setup(&operation, alg);
@@ -383,8 +338,6 @@ static void hash_a_message(void)
 
     /* Clean up hash operation context */
     psa_hash_abort(&operation);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void verify_a_hash(void)
@@ -402,13 +355,6 @@ static void verify_a_hash(void)
 
     printf("Verify a hash...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Verify message hash */
     status = psa_hash_setup(&operation, alg);
@@ -431,8 +377,6 @@ static void verify_a_hash(void)
 
     /* Clean up hash operation context */
     psa_hash_abort(&operation);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void generate_a_random_value(void)
@@ -443,13 +387,6 @@ static void generate_a_random_value(void)
     printf("Generate random...\t");
     fflush(stdout);
 
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
-
     status = psa_generate_random(random, sizeof(random));
     if (status != PSA_SUCCESS) {
         printf("Failed to generate a random value\n");
@@ -457,9 +394,6 @@ static void generate_a_random_value(void)
     }
 
     printf("Generated random data\n");
-
-    /* Clean up */
-    mbedtls_psa_crypto_free();
 }
 
 static void derive_a_new_key_from_an_existing_key(void)
@@ -487,13 +421,6 @@ static void derive_a_new_key_from_an_existing_key(void)
 
     printf("Derive a key (HKDF)...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Import a key for use in key derivation. If such a key has already been
      * generated or imported, you can skip this part. */
@@ -559,8 +486,6 @@ static void derive_a_new_key_from_an_existing_key(void)
     /* Destroy the keys */
     psa_destroy_key(derived_key);
     psa_destroy_key(base_key);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void authenticate_and_encrypt_a_message(void)
@@ -588,13 +513,6 @@ static void authenticate_and_encrypt_a_message(void)
 
     printf("Authenticate encrypt...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     output_size = sizeof(input_data) + tag_length;
     output_data = (uint8_t *)malloc(output_size);
@@ -630,8 +548,6 @@ static void authenticate_and_encrypt_a_message(void)
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void authenticate_and_decrypt_a_message(void)
@@ -658,13 +574,6 @@ static void authenticate_and_decrypt_a_message(void)
 
     printf("Authenticate decrypt...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     output_size = sizeof(input_data);
     output_data = (uint8_t *)malloc(output_size);
@@ -704,8 +613,6 @@ static void authenticate_and_decrypt_a_message(void)
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 static void generate_and_export_a_public_key()
@@ -721,13 +628,6 @@ static void generate_and_export_a_public_key()
 
     printf("Generate a key pair...\t");
     fflush(stdout);
-
-    /* Initialize PSA Crypto */
-    status = psa_crypto_init();
-    if (status != PSA_SUCCESS) {
-        printf("Failed to initialize PSA Crypto\n");
-        return;
-    }
 
     /* Generate a key */
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN);
@@ -754,13 +654,18 @@ static void generate_and_export_a_public_key()
 
     /* Destroy the key */
     psa_destroy_key(handle);
-
-    mbedtls_psa_crypto_free();
 }
 
 int main(void)
 {
     printf("-- Begin PSA Crypto Getting Started --\n\n");
+
+    /* Initialize PSA Crypto */
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        printf("Failed to initialize PSA Crypto\n");
+        return -1;
+    }
 
     import_a_key(AES_KEY, sizeof(AES_KEY));
     sign_a_message_using_rsa(RSA_KEY, sizeof(RSA_KEY));

--- a/getting-started/main.cpp
+++ b/getting-started/main.cpp
@@ -763,7 +763,7 @@ static void generate_and_export_a_public_key()
 
 int main(void)
 {
-    printf("-- Begin Mbed Crypto Getting Started --\n\n");
+    printf("-- Begin PSA Crypto Getting Started --\n\n");
 
     import_a_key(AES_KEY, sizeof(AES_KEY));
     sign_a_message_using_rsa(RSA_KEY, sizeof(RSA_KEY));
@@ -777,7 +777,7 @@ int main(void)
     authenticate_and_decrypt_a_message();
     generate_and_export_a_public_key();
 
-    printf("\n-- End Mbed Crypto Getting Started --\n");
+    printf("\n-- End PSA Crypto Getting Started --\n");
 
     return 0;
 }

--- a/getting-started/main.cpp
+++ b/getting-started/main.cpp
@@ -139,7 +139,13 @@ static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
 {
     psa_status_t status;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    static const uint8_t hash[] = "INPUT_FOR_SIGN";
+    psa_algorithm_t alg = PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_SHA_256);
+    // SHA-256 of {'a', 'b', 'c'}
+    static const uint8_t hash[PSA_HASH_SIZE(PSA_ALG_SHA_256)] = {
+        0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde,
+        0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+        0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad
+    };
     uint8_t signature[PSA_ASYMMETRIC_SIGNATURE_MAX_SIZE] = {0};
     size_t signature_length;
     psa_key_handle_t handle;
@@ -149,7 +155,7 @@ static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
 
     /* Set key attributes */
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN);
-    psa_set_key_algorithm(&attributes, PSA_ALG_RSA_PKCS1V15_SIGN_RAW);
+    psa_set_key_algorithm(&attributes, alg);
     psa_set_key_type(&attributes, PSA_KEY_TYPE_RSA_KEY_PAIR);
     psa_set_key_bits(&attributes, 1024);
 
@@ -161,7 +167,7 @@ static void sign_a_message_using_rsa(const uint8_t *key, size_t key_len)
     }
 
     /* Sign message using the key */
-    status = psa_asymmetric_sign(handle, PSA_ALG_RSA_PKCS1V15_SIGN_RAW,
+    status = psa_asymmetric_sign(handle, alg,
                                  hash, sizeof(hash),
                                  signature, sizeof(signature),
                                  &signature_length);

--- a/getting-started/main.cpp
+++ b/getting-started/main.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include "psa/crypto.h"
-#include "mbedtls/version.h"
 #include <string.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -98,12 +97,10 @@ static const uint8_t RSA_KEY[] =
     0xbb, 0xfe, 0x1c, 0x99, 0x77, 0x81, 0x44, 0x7a, 0x2b, 0x24,
 };
 
-#if !defined(MBEDTLS_PSA_CRYPTO_C) || (MBEDTLS_VERSION_NUMBER < 0x02130000)
+#if (PSA_CRYPTO_API_VERSION_MAJOR != 1)
 int main(void)
 {
-    printf("Not all of the requirements are met:\n"
-           "  - MBEDTLS_PSA_CRYPTO_C\n"
-           "  - PSA Crypto API v1.0b3\n");
+    printf("Requirement not met: PSA_CRYPTO_API_VERSION_MAJOR == 1\n");
     return 0;
 }
 #else
@@ -781,4 +778,4 @@ int main(void)
 
     return 0;
 }
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+#endif /* PSA_CRYPTO_API_VERSION_MAJOR */

--- a/getting-started/mbed_app.json
+++ b/getting-started/mbed_app.json
@@ -2,7 +2,7 @@
     "target_overrides": {
         "*": {
              "platform.stdio-convert-newlines": true,
-             "target.features_add" : ["EXPERIMENTAL_API"],
+             "target.features_add" : ["EXPERIMENTAL_API", "PSA"],
              "target.components_remove": ["SD"]
         }
     },

--- a/tests/getting-started.log
+++ b/tests/getting-started.log
@@ -1,4 +1,4 @@
--- Begin Mbed Crypto Getting Started --
+-- Begin PSA Crypto Getting Started --
 
 Import an AES key...	Imported a key
 Sign a message...	Signed a message
@@ -12,4 +12,4 @@ Authenticate encrypt...	Authenticated and encrypted
 Authenticate decrypt...	Authenticated and decrypted
 Generate a key pair...	Exported a public key
 
--- End Mbed Crypto Getting Started --
+-- End PSA Crypto Getting Started --


### PR DESCRIPTION
Use only the standard PSA Crypto API, to support TF-M:
* Check PSA Crypto API major version instead of Mbed TLS version, to avoid direct dependency on an Mbed TLS header.
* Call `mbedtls_psa_crypto_free()` (not part of the PSA Crypto API) when using Mbed OS PSA only.
* Enable SHA-256 hash for PKCS1v15 message signing, because CryptoCell 312 does not allow no hash.
* Reword: Mbed Crypto -> PSA Crypto
* Add ARM_MUSCA_S1 to Travis as a TF-M target. Also update the Ubuntu image to Focal, hoping to solve the bootloader image signing failure.

General fixes & improvements
* Fix Travis build
* Update README with Mbed CLI 2 instructions
* Enable PSA by default (to make it slightly easier for users to enable Mbed Crypto)