### PR TITLE
Update for mbed-os-6.16.0

### DIFF
--- a/getting-started/mbed-os.lib
+++ b/getting-started/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.16.0 release of mbed-os. 